### PR TITLE
Update User_manual.Rmd

### DIFF
--- a/vignettes/User_manual.Rmd
+++ b/vignettes/User_manual.Rmd
@@ -11,7 +11,7 @@ vignette: >
 
 
 ```{r setup, include = FALSE, warning = FALSE}
-knitr::opts_chunk$set(comment = FALSE, warning = FALSE, message = FALSE)
+knitr::opts_chunk$set(comment = "#>", warning = FALSE, message = FALSE)
 ```
 
 


### PR DESCRIPTION
comment options fully specified as string, `#>` to have it stand out as being output.

Alternative: one can also use the empty `""` string

Could be a direct fix to https://github.com/snaketron/scBubbletree/issues/3